### PR TITLE
Create gaming landing page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+node_modules/
+.next/
+.env
+.env.*
+dist/
+coverage/
+*.log
+*.tmp
+*.swp

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -1,38 +1,170 @@
-import { useState } from 'react';
 import { useRouter } from 'next/router';
-import TextField from '@mui/material/TextField';
+import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Chip from '@mui/material/Chip';
+import Grid from '@mui/material/Grid';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
 import Layout from '../components/Layout';
-import api, { setAuthToken } from '../utils/api';
+import styles from '../styles/LandingPage.module.css';
 
-export default function Login({ darkMode, toggleDarkMode }) {
+const games = [
+  {
+    title: 'Neon Drift',
+    genre: 'Racing',
+    blurb: 'Dash through neon skylines, upgrade your ride, and outrun the leaderboard.',
+  },
+  {
+    title: 'Starfall Tactics',
+    genre: 'Strategy',
+    blurb: 'Command fleets, conquer sectors, and forge alliances in a living galaxy.',
+  },
+  {
+    title: 'Mystic Hollow',
+    genre: 'Adventure',
+    blurb: 'Solve ancient puzzles, tame forest spirits, and unravel the Hollow’s secret.',
+  },
+];
+
+const features = [
+  { title: 'Curated Worlds', copy: 'Discover story-driven titles and quick-fire arcade hits in one place.' },
+  { title: 'Play Anywhere', copy: 'Optimized for desktop, tablet, and mobile so you never drop the action.' },
+  { title: 'Instant Access', copy: 'Jump in with one tap—no installs, no waiting, just pure gameplay.' },
+  { title: 'Community Events', copy: 'Daily tournaments, seasonal drops, and exclusive creator spotlights.' },
+];
+
+export default function LandingPage({ darkMode, toggleDarkMode }) {
   const router = useRouter();
-  const [formData, setFormData] = useState({ email: '', password: '' });
-
-  const onChange = e => setFormData({ ...formData, [e.target.name]: e.target.value });
-
-  const onSubmit = async e => {
-    e.preventDefault();
-    try {
-      const res = await api.post('/auth/login', formData);
-      setAuthToken(res.data.token);
-      router.push('/dashboard');
-    } catch (err) {
-      console.error(err);
-      alert('Login failed');
-    }
-  };
 
   return (
     <Layout darkMode={darkMode} toggleDarkMode={toggleDarkMode}>
-      <form onSubmit={onSubmit}>
-        <TextField label="Email" name="email" fullWidth margin="normal" onChange={onChange} />
-        <TextField label="Password" type="password" name="password" fullWidth margin="normal" onChange={onChange} />
-        <Button variant="contained" type="submit" sx={{ mt: 2 }}>Login</Button>
-      </form>
-      <Button variant="text" onClick={() => router.push('/signup')} sx={{ mt: 2 }}>
-        Sign Up
-      </Button>
+      <Box className={styles.hero}>
+        <Stack spacing={2}>
+          <Chip label="New" color="primary" className={styles.badge} />
+          <Typography variant="h3" component="h1" fontWeight={800}>
+            Play bold. <span className={styles.highlight}>Discover</span> the games everyone is talking about.
+          </Typography>
+          <Typography variant="h6" component="p" className={styles.subhead}>
+            Build your squad, unlock achievements, and stream-ready moments—all from one landing hub
+            designed for gamers.
+          </Typography>
+          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
+            <Button variant="contained" size="large" onClick={() => router.push('/signup')}>
+              Start free
+            </Button>
+            <Button variant="outlined" size="large" onClick={() => router.push('/dashboard')}>
+              View dashboard
+            </Button>
+          </Stack>
+        </Stack>
+        <Box className={styles.heroCard}>
+          <Typography variant="overline" color="text.secondary" letterSpacing={2}>
+            TODAY’S SPOTLIGHT
+          </Typography>
+          <Typography variant="h4" component="h2" fontWeight={700} sx={{ mb: 1 }}>
+            Velocity Season Pass
+          </Typography>
+          <Typography variant="body1" color="text.secondary">
+            Unlock the Driftblade, speed trials, and three exclusive neon arenas. Hit Tier 10 to earn
+            the animated “Afterburn” banner.
+          </Typography>
+          <Stack direction="row" spacing={1} sx={{ mt: 2 }}>
+            <Chip label="Limited" color="secondary" size="small" />
+            <Chip label="Multiplayer" variant="outlined" size="small" />
+          </Stack>
+          <Button
+            fullWidth
+            variant="contained"
+            color="secondary"
+            sx={{ mt: 3 }}
+            onClick={() => router.push('/signup')}
+          >
+            Claim your pass
+          </Button>
+        </Box>
+      </Box>
+
+      <Box sx={{ mt: 6 }}>
+        <Typography variant="overline" color="text.secondary">
+          Top picks
+        </Typography>
+        <Typography variant="h4" component="h3" fontWeight={700} sx={{ mb: 3 }}>
+          Games everyone is grinding right now
+        </Typography>
+        <Grid container spacing={3}>
+          {games.map(game => (
+            <Grid item xs={12} md={4} key={game.title}>
+              <Card className={styles.gameCard}>
+                <CardContent>
+                  <Stack direction="row" justifyContent="space-between" alignItems="center">
+                    <Typography variant="h6" fontWeight={700}>
+                      {game.title}
+                    </Typography>
+                    <Chip label={game.genre} size="small" color="primary" variant="outlined" />
+                  </Stack>
+                  <Typography variant="body2" color="text.secondary" sx={{ mt: 1.5 }}>
+                    {game.blurb}
+                  </Typography>
+                  <Button
+                    variant="text"
+                    size="small"
+                    sx={{ mt: 2 }}
+                    onClick={() => router.push('/signup')}
+                  >
+                    Jump in
+                  </Button>
+                </CardContent>
+              </Card>
+            </Grid>
+          ))}
+        </Grid>
+      </Box>
+
+      <Box sx={{ mt: 8 }}>
+        <Typography variant="overline" color="text.secondary">
+          Why players stay
+        </Typography>
+        <Typography variant="h4" component="h3" fontWeight={700} sx={{ mb: 3 }}>
+          Built to keep your streak alive
+        </Typography>
+        <Grid container spacing={3}>
+          {features.map(feature => (
+            <Grid item xs={12} sm={6} md={3} key={feature.title}>
+              <Card className={styles.featureCard}>
+                <CardContent>
+                  <Typography variant="h6" fontWeight={700}>
+                    {feature.title}
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+                    {feature.copy}
+                  </Typography>
+                </CardContent>
+              </Card>
+            </Grid>
+          ))}
+        </Grid>
+      </Box>
+
+      <Box className={styles.cta}>
+        <Stack spacing={2}>
+          <Typography variant="h4" component="h3" fontWeight={800}>
+            Ready to press start?
+          </Typography>
+          <Typography variant="body1" color="text.secondary">
+            Create your account, sync your library, and be the first to drop into new releases and live events.
+          </Typography>
+          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
+            <Button variant="contained" size="large" color="secondary" onClick={() => router.push('/signup')}>
+              Create account
+            </Button>
+            <Button variant="outlined" size="large" onClick={() => router.push('/dashboard')}>
+              Explore dashboard
+            </Button>
+          </Stack>
+        </Stack>
+      </Box>
     </Layout>
   );
 }

--- a/frontend/styles/LandingPage.module.css
+++ b/frontend/styles/LandingPage.module.css
@@ -1,0 +1,70 @@
+.hero {
+  display: grid;
+  grid-template-columns: 1.2fr 1fr;
+  gap: 2rem;
+  align-items: stretch;
+  background: radial-gradient(circle at 20% 20%, rgba(111, 98, 255, 0.25), transparent 45%),
+    radial-gradient(circle at 80% 0%, rgba(255, 120, 180, 0.25), transparent 40%),
+    linear-gradient(135deg, rgba(44, 47, 112, 0.08), rgba(30, 32, 60, 0.08));
+  border-radius: 24px;
+  padding: 2.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.15);
+}
+
+.heroCard {
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  padding: 1.75rem;
+  backdrop-filter: blur(10px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+.badge {
+  align-self: flex-start;
+}
+
+.highlight {
+  color: #7c5dff;
+}
+
+.subhead {
+  max-width: 42rem;
+  opacity: 0.9;
+}
+
+.gameCard {
+  height: 100%;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0.08));
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+}
+
+.featureCard {
+  height: 100%;
+  border-radius: 16px;
+  border: 1px dashed rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.cta {
+  margin-top: 4rem;
+  padding: 2.5rem;
+  border-radius: 20px;
+  background: linear-gradient(120deg, rgba(124, 93, 255, 0.15), rgba(255, 255, 255, 0.04));
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+@media (max-width: 900px) {
+  .hero {
+    grid-template-columns: 1fr;
+  }
+
+  .heroCard {
+    order: -1;
+  }
+}


### PR DESCRIPTION
## Summary
- replace the home page with a gamer-focused landing layout featuring hero messaging, top picks, and CTAs
- add dedicated styling for hero, feature, and game highlight cards to match the new layout
- add a repository-level .gitignore to avoid committing build and dependency artifacts

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945bceaac4c832e85ff5ce2572b32d7)